### PR TITLE
Add componentized API docs, fix Swagger assets, and auto-build on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ This runs on `docker compose up` (not during image build) and only after Postgre
 ## API Documentation
 The API returns JSON and uses standard HTTP status codes. All task listings are paginated by default with 10 items per page.
 
+### Swagger (OpenAPI)
+- UI: http://localhost:8000/api/documentation
+- JSON: http://localhost:8000/docs (file lives at `backend/storage/api-docs/api-docs.json`).
+- Auto-build: the `api` container builds the docs at startup.
+- Manual refresh: `docker compose exec api php artisan l5-swagger:generate`
+- Tip: whenever you change OpenAPI annotations, refresh the docs to see updates.
+
 ## API Endpoints
 - `GET /api/tasks` – list tasks (always paginated; default `per_page=10`)
 - `POST /api/tasks` – create a task

--- a/backend/app/OpenApi/OpenApi.php
+++ b/backend/app/OpenApi/OpenApi.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Info(
+    version: '1.0.0',
+    title: 'Task Manager API',
+    description: 'OpenAPI documentation for the Task Manager backend.'
+)]
+#[OA\Server(
+    url: 'http://localhost:8000',
+    description: 'Local Nginx -> Laravel'
+)]
+#[OA\Tag(
+    name: 'Tasks',
+    description: 'CRUD operations and statistics for tasks.'
+)]
+class OpenApi
+{
+}
+

--- a/backend/app/OpenApi/Parameters/CommonParameters.php
+++ b/backend/app/OpenApi/Parameters/CommonParameters.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Parameters;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Parameter(
+    parameter: 'PerPageParam', name: 'per_page', in: 'query', required: false,
+    description: 'Items per page (1-100). Default: 10.',
+    schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100)
+)]
+#[OA\Parameter(
+    parameter: 'PageParam', name: 'page', in: 'query', required: false,
+    description: 'Page number (1-indexed).',
+    schema: new OA\Schema(type: 'integer', minimum: 1)
+)]
+#[OA\Parameter(
+    parameter: 'SortByParam', name: 'sort_by', in: 'query', required: false,
+    description: 'Field to sort by.',
+    schema: new OA\Schema(type: 'string', enum: ['id', 'title', 'created_at', 'updated_at', 'due_date'])
+)]
+#[OA\Parameter(
+    parameter: 'SortDirParam', name: 'sort_dir', in: 'query', required: false,
+    description: 'Sort direction.',
+    schema: new OA\Schema(type: 'string', enum: ['asc', 'desc'])
+)]
+#[OA\Parameter(
+    parameter: 'TitleParam', name: 'title', in: 'query', required: false,
+    description: 'Filter by title (contains).',
+    schema: new OA\Schema(type: 'string')
+)]
+#[OA\Parameter(
+    parameter: 'DescriptionParam', name: 'description', in: 'query', required: false,
+    description: 'Filter by description (contains).',
+    schema: new OA\Schema(type: 'string')
+)]
+#[OA\Parameter(
+    parameter: 'StatusParam', name: 'status', in: 'query', required: false,
+    description: 'Filter by status.',
+    schema: new OA\Schema(type: 'string', enum: ['pending', 'in_progress', 'completed'])
+)]
+#[OA\Parameter(
+    parameter: 'PriorityParam', name: 'priority', in: 'query', required: false,
+    description: 'Filter by priority.',
+    schema: new OA\Schema(type: 'string', enum: ['low', 'medium', 'high'])
+)]
+#[OA\Parameter(
+    parameter: 'DueDateFromParam', name: 'due_date_from', in: 'query', required: false,
+    description: 'Due date >= (YYYY-MM-DD).',
+    schema: new OA\Schema(type: 'string', format: 'date')
+)]
+#[OA\Parameter(
+    parameter: 'DueDateToParam', name: 'due_date_to', in: 'query', required: false,
+    description: 'Due date <= (YYYY-MM-DD).',
+    schema: new OA\Schema(type: 'string', format: 'date')
+)]
+#[OA\Parameter(parameter: 'CreatedFromParam', name: 'created_from', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date'))]
+#[OA\Parameter(parameter: 'CreatedToParam', name: 'created_to', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date'))]
+#[OA\Parameter(parameter: 'UpdatedFromParam', name: 'updated_from', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date'))]
+#[OA\Parameter(parameter: 'UpdatedToParam', name: 'updated_to', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date'))]
+#[OA\Parameter(
+    parameter: 'TaskIdPathParam', name: 'task', in: 'path', required: true,
+    description: 'Task identifier',
+    schema: new OA\Schema(type: 'integer', format: 'int64')
+)]
+class CommonParameters
+{
+}
+

--- a/backend/app/OpenApi/Paths/TaskPaths.php
+++ b/backend/app/OpenApi/Paths/TaskPaths.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Paths;
+
+use OpenApi\Attributes as OA;
+
+class TaskPaths
+{
+    #[OA\Get(
+        path: '/api/tasks',
+        tags: ['Tasks'],
+        summary: 'List tasks',
+        parameters: [
+            new OA\Parameter(ref: '#/components/parameters/PerPageParam'),
+            new OA\Parameter(ref: '#/components/parameters/PageParam'),
+            new OA\Parameter(ref: '#/components/parameters/SortByParam'),
+            new OA\Parameter(ref: '#/components/parameters/SortDirParam'),
+            new OA\Parameter(ref: '#/components/parameters/StatusParam'),
+            new OA\Parameter(ref: '#/components/parameters/PriorityParam'),
+            new OA\Parameter(ref: '#/components/parameters/TitleParam'),
+            new OA\Parameter(ref: '#/components/parameters/DescriptionParam'),
+            new OA\Parameter(ref: '#/components/parameters/DueDateFromParam'),
+            new OA\Parameter(ref: '#/components/parameters/DueDateToParam'),
+            new OA\Parameter(ref: '#/components/parameters/CreatedFromParam'),
+            new OA\Parameter(ref: '#/components/parameters/CreatedToParam'),
+            new OA\Parameter(ref: '#/components/parameters/UpdatedFromParam'),
+            new OA\Parameter(ref: '#/components/parameters/UpdatedToParam'),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated tasks', content: new OA\JsonContent(ref: '#/components/schemas/TaskCollection')),
+            new OA\Response(response: 422, description: 'Validation error', content: new OA\JsonContent(ref: '#/components/schemas/ValidationError')),
+        ]
+    )]
+    public function listTasks(): void {}
+
+    #[OA\Post(
+        path: '/api/tasks',
+        tags: ['Tasks'],
+        summary: 'Create a new task',
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(ref: '#/components/schemas/TaskInput')),
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/Task')),
+            new OA\Response(response: 422, description: 'Validation error', content: new OA\JsonContent(ref: '#/components/schemas/ValidationError')),
+        ]
+    )]
+    public function createTask(): void {}
+
+    #[OA\Get(
+        path: '/api/tasks/{task}',
+        tags: ['Tasks'],
+        summary: 'Retrieve a task',
+        parameters: [new OA\Parameter(ref: '#/components/parameters/TaskIdPathParam')],
+        responses: [
+            new OA\Response(response: 200, description: 'OK', content: new OA\JsonContent(ref: '#/components/schemas/Task')),
+            new OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/NotFoundError')),
+        ]
+    )]
+    public function getTask(): void {}
+
+    #[OA\Put(
+        path: '/api/tasks/{task}',
+        tags: ['Tasks'],
+        summary: 'Replace a task',
+        parameters: [new OA\Parameter(ref: '#/components/parameters/TaskIdPathParam')],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(ref: '#/components/schemas/TaskInput')),
+        responses: [
+            new OA\Response(response: 200, description: 'OK', content: new OA\JsonContent(ref: '#/components/schemas/Task')),
+            new OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/NotFoundError')),
+            new OA\Response(response: 422, description: 'Validation error', content: new OA\JsonContent(ref: '#/components/schemas/ValidationError')),
+        ]
+    )]
+    public function replaceTask(): void {}
+
+    #[OA\Patch(
+        path: '/api/tasks/{task}',
+        tags: ['Tasks'],
+        summary: 'Update a task',
+        parameters: [new OA\Parameter(ref: '#/components/parameters/TaskIdPathParam')],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(ref: '#/components/schemas/TaskUpdateInput')),
+        responses: [
+            new OA\Response(response: 200, description: 'OK', content: new OA\JsonContent(ref: '#/components/schemas/Task')),
+            new OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/NotFoundError')),
+            new OA\Response(response: 422, description: 'Validation error', content: new OA\JsonContent(ref: '#/components/schemas/ValidationError')),
+        ]
+    )]
+    public function updateTask(): void {}
+
+    #[OA\Delete(
+        path: '/api/tasks/{task}',
+        tags: ['Tasks'],
+        summary: 'Delete a task',
+        parameters: [new OA\Parameter(ref: '#/components/parameters/TaskIdPathParam')],
+        responses: [
+            new OA\Response(response: 204, description: 'No content'),
+            new OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/NotFoundError')),
+        ]
+    )]
+    public function deleteTask(): void {}
+
+    #[OA\Get(
+        path: '/api/tasks/statistics',
+        tags: ['Tasks'],
+        summary: 'Task statistics',
+        responses: [new OA\Response(response: 200, description: 'OK', content: new OA\JsonContent(ref: '#/components/schemas/TaskStatistics'))]
+    )]
+    public function taskStatistics(): void {}
+}
+

--- a/backend/app/OpenApi/Schemas/NotFoundErrorSchema.php
+++ b/backend/app/OpenApi/Schemas/NotFoundErrorSchema.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'NotFoundError',
+    type: 'object',
+    required: ['message'],
+    properties: [
+        new OA\Property(property: 'message', type: 'string', example: 'Resource not found.'),
+    ]
+)]
+class NotFoundErrorSchema
+{
+}
+

--- a/backend/app/OpenApi/Schemas/TaskCollectionSchema.php
+++ b/backend/app/OpenApi/Schemas/TaskCollectionSchema.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'TaskCollection',
+    type: 'object',
+    properties: [
+        new OA\Property(
+            property: 'data',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/Task')
+        ),
+        new OA\Property(
+            property: 'links',
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'first', type: 'string', nullable: true),
+                new OA\Property(property: 'last', type: 'string', nullable: true),
+                new OA\Property(property: 'prev', type: 'string', nullable: true),
+                new OA\Property(property: 'next', type: 'string', nullable: true),
+            ]
+        ),
+        new OA\Property(
+            property: 'meta',
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'current_page', type: 'integer', example: 1),
+                new OA\Property(property: 'last_page', type: 'integer', example: 5),
+                new OA\Property(property: 'per_page', type: 'integer', example: 10),
+                new OA\Property(property: 'total', type: 'integer', example: 47),
+                new OA\Property(property: 'from', type: 'integer', nullable: true),
+                new OA\Property(property: 'to', type: 'integer', nullable: true),
+            ]
+        ),
+    ]
+)]
+class TaskCollectionSchema
+{
+}
+

--- a/backend/app/OpenApi/Schemas/TaskInputSchema.php
+++ b/backend/app/OpenApi/Schemas/TaskInputSchema.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'TaskInput',
+    type: 'object',
+    required: ['title', 'description', 'due_date'],
+    properties: [
+        new OA\Property(property: 'title', type: 'string', maxLength: 100, example: 'Plan sprint backlog'),
+        new OA\Property(property: 'description', type: 'string', maxLength: 500, example: 'Refine the backlog ahead of sprint planning.'),
+        new OA\Property(property: 'status', type: 'string', enum: ['pending', 'in_progress', 'completed'], nullable: true),
+        new OA\Property(property: 'priority', type: 'string', enum: ['low', 'medium', 'high'], nullable: true),
+        new OA\Property(property: 'due_date', type: 'string', format: 'date', example: '2025-01-15'),
+    ]
+)]
+class TaskInputSchema
+{
+}
+

--- a/backend/app/OpenApi/Schemas/TaskSchema.php
+++ b/backend/app/OpenApi/Schemas/TaskSchema.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'Task',
+    type: 'object',
+    required: ['id', 'title', 'description', 'status', 'priority', 'createdAt', 'updatedAt'],
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', format: 'int64', example: 42),
+        new OA\Property(property: 'title', type: 'string', maxLength: 100, example: 'Plan sprint backlog'),
+        new OA\Property(property: 'description', type: 'string', maxLength: 500, example: 'Refine the backlog ahead of sprint planning.'),
+        new OA\Property(property: 'status', type: 'string', enum: ['pending', 'in_progress', 'completed'], example: 'pending'),
+        new OA\Property(property: 'priority', type: 'string', enum: ['low', 'medium', 'high'], example: 'medium'),
+        new OA\Property(property: 'dueDate', type: 'string', format: 'date-time', nullable: true, example: '2025-01-15T12:00:00+00:00'),
+        new OA\Property(property: 'createdAt', type: 'string', format: 'date-time', example: '2025-01-01T08:30:00+00:00'),
+        new OA\Property(property: 'updatedAt', type: 'string', format: 'date-time', example: '2025-01-05T10:45:00+00:00'),
+    ]
+)]
+class TaskSchema
+{
+}
+

--- a/backend/app/OpenApi/Schemas/TaskStatisticsSchema.php
+++ b/backend/app/OpenApi/Schemas/TaskStatisticsSchema.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'TaskStatistics',
+    type: 'object',
+    required: ['totalTasks', 'byStatus', 'byPriority'],
+    properties: [
+        new OA\Property(property: 'totalTasks', type: 'integer', example: 25),
+        new OA\Property(
+            property: 'byStatus',
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'pending', type: 'integer', example: 10),
+                new OA\Property(property: 'in_progress', type: 'integer', example: 8),
+                new OA\Property(property: 'completed', type: 'integer', example: 7),
+            ]
+        ),
+        new OA\Property(
+            property: 'byPriority',
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'low', type: 'integer', example: 9),
+                new OA\Property(property: 'medium', type: 'integer', example: 12),
+                new OA\Property(property: 'high', type: 'integer', example: 4),
+            ]
+        ),
+    ]
+)]
+class TaskStatisticsSchema
+{
+}
+

--- a/backend/app/OpenApi/Schemas/TaskUpdateInputSchema.php
+++ b/backend/app/OpenApi/Schemas/TaskUpdateInputSchema.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'TaskUpdateInput',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'title', type: 'string', maxLength: 100),
+        new OA\Property(property: 'description', type: 'string', maxLength: 500),
+        new OA\Property(property: 'status', type: 'string', enum: ['pending', 'in_progress', 'completed']),
+        new OA\Property(property: 'priority', type: 'string', enum: ['low', 'medium', 'high']),
+        new OA\Property(property: 'due_date', type: 'string', format: 'date'),
+    ]
+)]
+class TaskUpdateInputSchema
+{
+}
+

--- a/backend/app/OpenApi/Schemas/ValidationErrorSchema.php
+++ b/backend/app/OpenApi/Schemas/ValidationErrorSchema.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ValidationError',
+    type: 'object',
+    required: ['message', 'errors'],
+    properties: [
+        new OA\Property(property: 'message', type: 'string', example: 'The given data was invalid.'),
+        new OA\Property(
+            property: 'errors',
+            type: 'object',
+            additionalProperties: new OA\AdditionalProperties(
+                type: 'array',
+                items: new OA\Items(type: 'string')
+            )
+        ),
+    ]
+)]
+class ValidationErrorSchema
+{
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -7,8 +7,10 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "darkaonline/l5-swagger": "^8.6",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "zircote/swagger-php": "^4.11"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c514d8f7b9fc5970bdd94287905ef584",
+    "content-hash": "f14e64525f25748bb50286999d9f2cf2",
     "packages": [
         {
             "name": "brick/math",
@@ -136,6 +136,86 @@
             "time": "2024-02-09T16:56:22+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "8.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "4cf2b3faae9e9cffd05e4eb6e066741bf56f0a85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/4cf2b3faae9e9cffd05e4eb6e066741bf56f0a85",
+                "reference": "4cf2b3faae9e9cffd05e4eb6e066741bf56f0a85",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^11.0 || ^10.0 || ^9.0 || >=8.40.0 || ^7.0",
+                "php": "^7.2 || ^8.0",
+                "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^3.2.0 || ^4.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^10.0 || ^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/8.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-06T14:54:32+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -209,6 +289,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2589,6 +2745,55 @@
             "time": "2025-08-21T11:53:16+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3275,6 +3480,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
             "time": "2025-09-04T20:59:21+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.29.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "5f5e006931b77c5f9fe2613143ab435f0c059a8f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/5f5e006931b77c5f9fe2613143ab435f0c059a8f",
+                "reference": "5f5e006931b77c5f9fe2613143ab435f0c059a8f",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.29.3"
+            },
+            "time": "2025-10-03T09:39:56+00:00"
         },
         {
             "name": "symfony/clock",
@@ -5754,6 +6020,82 @@
             "time": "2025-09-11T10:12:26+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.3.0",
             "source": {
@@ -6023,6 +6365,87 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "4.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^1.7 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17 || 3.62.0",
+                "phpstan/phpstan": "^1.6",
+                "phpunit/phpunit": ">=8",
+                "vimeo/psalm": "^4.23"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.7 || ^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/4.11.1"
+            },
+            "time": "2024-10-15T19:20:02+00:00"
         }
     ],
     "packages-dev": [
@@ -8260,82 +8683,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/backend/config/l5-swagger.php
+++ b/backend/config/l5-swagger.php
@@ -1,0 +1,318 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];

--- a/backend/config/l5-swagger.php
+++ b/backend/config/l5-swagger.php
@@ -5,7 +5,7 @@ return [
     'documentations' => [
         'default' => [
             'api' => [
-                'title' => 'L5 Swagger UI',
+                'title' => 'Task Manager API',
             ],
 
             'routes' => [

--- a/backend/docker/entrypoint.sh
+++ b/backend/docker/entrypoint.sh
@@ -32,6 +32,7 @@ mkdir -p storage/framework/cache \
          storage/framework/sessions \
          storage/framework/views \
          storage/logs \
+         storage/api-docs \
          bootstrap/cache
 chmod -R 775 storage bootstrap/cache || true
 chown -R www-data:www-data storage bootstrap/cache || true
@@ -54,6 +55,10 @@ if [ -f artisan ]; then
 
   echo "Running migrations..."
   php artisan migrate --force || true
+
+  # Generate Swagger/OpenAPI docs so UI is ready
+  echo "Generating OpenAPI (Swagger) docs..."
+  php artisan l5-swagger:generate || true
 
 fi
 

--- a/backend/nginx/default.conf
+++ b/backend/nginx/default.conf
@@ -16,8 +16,14 @@ server {
     fastcgi_read_timeout 120;
   }
 
+  # Ensure L5-Swagger asset routes are handled by Laravel routes, not as static files
+  location ^~ /docs/asset/ {
+    try_files $uri /index.php?$query_string;
+  }
+
+  # Serve static files when they exist; otherwise, fall back to Laravel
   location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-    try_files $uri =404;
+    try_files $uri $uri/ /index.php?$query_string;
     expires 7d;
     access_log off;
   }

--- a/backend/resources/views/vendor/l5-swagger/index.blade.php
+++ b/backend/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{config('l5-swagger.documentations.'.$documentation.'.api.title')}}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            url: "{!! $urlToDocs !!}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary ##

- Adds a clean, componentized OpenAPI setup (Info/Server/Tags, Schemas, Parameters, and Paths) without modifying controllers.
- Fixes Nginx so Swagger UI assets resolve via Laravel instead of 404.
- Auto-builds Swagger docs on API container startup and documents manual refresh in README.

## Changes

- Dependencies: add l5-swagger and swagger-php.
- Nginx: route /docs/asset/* through Laravel fallback.
- OpenAPI:
    - backend/app/OpenApi/OpenApi.php (Info/Server/Tag)
    - backend/app/OpenApi/Schemas/* (Task, inputs, collection, statistics, errors)
    - backend/app/OpenApi/Parameters/CommonParameters.php (pagination, filters, path id)
    - backend/app/OpenApi/Paths/TaskPaths.php (all task endpoints)
- Entrypoint: generate docs at startup and ensure storage/api-docs exists.

- Docs: README “Swagger (OpenAPI)” section in English with URLs and manual command.

## How to Test

- Rebuild/restart containers:
    - docker compose up -d --build api web
- Confirm docs are built automatically:
    - UI: http://localhost:8000/api/documentation
    - JSON: http://localhost:8000/docs
- Manual refresh (optional):
    - docker compose exec api php artisan l5-swagger:generate

## Notes

- No controller code changes; all documentation lives under app/OpenApi.
- Nginx change preserves static file performance while falling back to Laravel for Swagger asset routes.

## Risk

- Low. Nginx routing only affects /docs/asset/* and static fallback when files are missing.

## Rollback

- Revert the commits in this PR to restore previous behavior (no auto-built docs, prior Nginx config).